### PR TITLE
Fix wrong url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # zafer.info
-The codes and notes for [zafer.info](zafer.info) 
+The codes and notes for [zafer.info](https://zafer.info/) 


### PR DESCRIPTION
It was referring to a non-existing page (https://github.com/zafatar/zafer.info/blob/gh-pages/zafer.info)